### PR TITLE
Add dependency docs crawler and Streamlit search app

### DIFF
--- a/crawl4ai/__init__.py
+++ b/crawl4ai/__init__.py
@@ -65,6 +65,7 @@ from .deep_crawling import (
     DFSDeepCrawlStrategy,
     DeepCrawlDecorator,
 )
+from .docs_manager import DocsManager, DependencyDocsManager
 
 __all__ = [
     "AsyncLoggerBase",
@@ -124,7 +125,9 @@ __all__ = [
     "Crawl4aiDockerClient",
     "ProxyRotationStrategy",
     "RoundRobinProxyStrategy",
-    "ProxyConfig"
+    "ProxyConfig",
+    "DocsManager",
+    "DependencyDocsManager"
 ]
 
 

--- a/crawl4ai/dependency_docs_manager.py
+++ b/crawl4ai/dependency_docs_manager.py
@@ -1,0 +1,31 @@
+import requests
+from .legacy.docs_manager import DocsManager
+from .html2text import html2text
+
+
+class DependencyDocsManager(DocsManager):
+    """Manage documentation for third-party dependencies."""
+
+    def __init__(self, dependencies: dict[str, str] | None = None, logger=None):
+        super().__init__(logger)
+        self.dependencies = dependencies or {}
+
+    async def fetch_dependency_docs(self) -> None:
+        """Download and store docs for configured dependencies."""
+        for name, url in self.dependencies.items():
+            try:
+                resp = requests.get(url, timeout=15)
+                resp.raise_for_status()
+                md = html2text(resp.text)
+                doc_file = self.docs_dir / f"{name}.md"
+                with open(doc_file, "w", encoding="utf-8") as f:
+                    f.write(md)
+                self.logger.info(f"Fetched docs for {name}")
+            except Exception as e:
+                self.logger.error(f"Failed to fetch docs for {name}: {e}")
+
+    async def fetch_docs(self) -> bool:
+        """Fetch base docs and then dependency docs."""
+        base = await super().fetch_docs()
+        await self.fetch_dependency_docs()
+        return base

--- a/crawl4ai/docs_manager.py
+++ b/crawl4ai/docs_manager.py
@@ -1,0 +1,4 @@
+from .legacy.docs_manager import DocsManager  # re-export for compatibility
+from .dependency_docs_manager import DependencyDocsManager
+
+__all__ = ["DocsManager", "DependencyDocsManager"]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,27 @@
+import asyncio
+import streamlit as st
+from crawl4ai.dependency_docs_manager import DependencyDocsManager
+
+# Define dependencies and their docs URLs
+DEPENDENCIES = {
+    "playwright": "https://playwright.dev/python/docs/intro",
+    "beautifulsoup4": "https://www.crummy.com/software/BeautifulSoup/bs4/doc/",
+    "pydantic": "https://docs.pydantic.dev/latest/",
+}
+
+manager = DependencyDocsManager(DEPENDENCIES)
+
+st.title("Documentation Search")
+
+if st.button("Fetch Documentation"):
+    asyncio.run(manager.fetch_docs())
+    st.success("Documentation downloaded")
+
+if st.button("Build Index"):
+    asyncio.run(manager.llm_text.generate_index_files())
+    st.success("Index built")
+
+query = st.text_input("Search")
+if st.button("Search") and query:
+    result = manager.search(query, top_k=3)
+    st.text(result)


### PR DESCRIPTION
## Summary
- expose DocsManager at top-level for compatibility
- create `DependencyDocsManager` that downloads docs for key libraries
- integrate these in `__init__` for easier imports
- add a simple Streamlit app to fetch and search docs

## Testing
- `python -m py_compile crawl4ai/dependency_docs_manager.py crawl4ai/docs_manager.py streamlit_app.py`
- `pytest tests/test_cli_docs.py::test_cli -q` *(fails: No module named 'lxml')*

------
https://chatgpt.com/codex/tasks/task_e_684c7a180e54832f95eaa4bba9c859c3